### PR TITLE
Added OGS stat card to homepage

### DIFF
--- a/_data/_overview.json
+++ b/_data/_overview.json
@@ -46,5 +46,11 @@
         "users": "817,364",
         "percent": "2.30%",
         "change": "down"
+    },
+    {
+        "category": "Office of General Services",
+        "users": "85,212",
+        "percent": "1.8%",
+        "change": "up"
     }
 ]

--- a/_site/index.html
+++ b/_site/index.html
@@ -528,6 +528,41 @@
                     
                 </li>
             
+                <li class="stats-card-percent 
+                             stats-blue  
+                             
+                            ">
+                   
+
+
+                    
+                    <h4 class="stats-the
+                             stats-the-blue  
+                             
+                            ">
+                        85,212
+                    </h4>
+                    
+                    
+                    <p class="stats-description">
+                        Office of General Services
+                    </p>
+                    
+                    <div class="stats-icon-percent
+                             stats-blue  
+                             
+                            ">
+                        
+                            <span class="nysds-font-md stats-green"><i class="fas fa-arrow-up"></i></span>
+                            <span class="nysds-font-md">  1.8%</span>
+                            
+                        
+                    </div>
+                    
+                        <span class="stats-date-range"><i class="far fa-calendar"></i> May 1 - May 31</span>
+                    
+                </li>
+            
         </ul>
         
          


### PR DESCRIPTION
Stat card was never displayed when OGS looker studio report was added to the CSSP pages.